### PR TITLE
Enabled partial array updates in deepAssign()

### DIFF
--- a/reflections/shape/shape.js
+++ b/reflections/shape/shape.js
@@ -350,6 +350,9 @@ shapeReflections = {
 	 * @return {Array}  an array of the values of `obj`
 	 */
 	toArray: function(obj){
+		if (!typeReflections.isListLike(obj)) {
+			return obj;
+		}
 		var arr = [];
 		this.each(obj, function(value){
 			arr.push(value);


### PR DESCRIPTION
Updated toArray() to directly return non-list-like objects.